### PR TITLE
Recon elixir

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,8 +5,9 @@ FROM cimg/%%PARENT%%:2020.09
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
 # Install Erlang via Erlang Solutions' .deb
-ENV ERLANG_VERSION="23.1-1"
+ENV ERLANG_VERSION="23.1"
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+		libncurses5 \
 		libodbc1 \
 		libsctp1 \
 		libwxgtk3.0 && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -18,8 +18,11 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 
 # Install Elixir via Erlang Solutions' .deb
 ENV ELIXIR_VERSION=%%MAIN_VERSION%%
-RUN elixirDEB="https://packages.erlang-solutions.com/erlang/debian/pool/elixir_${ELIXIR_VERSION}-1~ubuntu~focal_all.deb" && \
-	curl -sSL -o elixir.deb $elixirDEB && \
-	sudo dpkg -i elixir.deb && \
-	rm -rf elixir.deb && \
+RUN ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/v${ELIXIR_VERSION}.tar.gz" && \
+	curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL && \
+	sudo mkdir -p /usr/local/src/elixir && \
+	sudo tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz && \
+	rm elixir-src.tar.gz && \
+	cd /usr/local/src/elixir && \
+	sudo make install clean && \
 	elixir --version


### PR DESCRIPTION
Since we can't use Erlang Solutions (upstream)'s .deb package right now, we're compiling from the official source.