### PR TITLE
Publish v1.12.2. [release]

### DIFF
--- a/1.12/Dockerfile
+++ b/1.12/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2021.04
+FROM cimg/base:2021.07
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -17,7 +17,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	sudo rm -rf erlang.deb /var/lib/apt/lists/*
 
 # Install Elixir via Erlang Solutions' .deb
-ENV ELIXIR_VERSION=1.12.1
+ENV ELIXIR_VERSION=1.12.2
 RUN ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/v${ELIXIR_VERSION}.tar.gz" && \
 	curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL && \
 	sudo mkdir -p /usr/local/src/elixir && \

--- a/1.12/browsers/Dockerfile
+++ b/1.12/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/elixir:1.12.1-node
+FROM cimg/elixir:1.12.2-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/1.12/node/Dockerfile
+++ b/1.12/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/elixir:1.12.1
+FROM cimg/elixir:1.12.2
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/%%PARENT%%:2021.04
+FROM cimg/%%PARENT%%:2021.07
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-docker build --file 1.12/Dockerfile -t cimg/elixir:1.12.1  -t cimg/elixir:1.12 .
-docker build --file 1.12/node/Dockerfile -t cimg/elixir:1.12.1-node  -t cimg/elixir:1.12-node .
-docker build --file 1.12/browsers/Dockerfile -t cimg/elixir:1.12.1-browsers  -t cimg/elixir:1.12-browsers .
+docker build --file 1.12/Dockerfile -t cimg/elixir:1.12.2  -t cimg/elixir:1.12 .
+docker build --file 1.12/node/Dockerfile -t cimg/elixir:1.12.2-node  -t cimg/elixir:1.12-node .
+docker build --file 1.12/browsers/Dockerfile -t cimg/elixir:1.12.2-browsers  -t cimg/elixir:1.12-browsers .


### PR DESCRIPTION
This also includes a base image bump to 2021.07.