### PR TITLE
Update OTP to v24.0.5

### DIFF
--- a/1.12/Dockerfile
+++ b/1.12/Dockerfile
@@ -5,7 +5,7 @@ FROM cimg/base:2021.07
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
 # Install Erlang via Erlang Solutions' .deb
-ENV ERLANG_VERSION="24.0"
+ENV ERLANG_VERSION="24.0.4"
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		libncurses5 \
 		libodbc1 \

--- a/1.12/Dockerfile
+++ b/1.12/Dockerfile
@@ -5,7 +5,7 @@ FROM cimg/base:2021.07
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
 # Install Erlang via Erlang Solutions' .deb
-ENV ERLANG_VERSION="24.0.4"
+ENV ERLANG_VERSION="24.0"
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		libncurses5 \
 		libodbc1 \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,7 +5,7 @@ FROM cimg/%%PARENT%%:2021.07
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
 # Install Erlang via Erlang Solutions' .deb
-ENV ERLANG_VERSION="24.0.4"
+ENV ERLANG_VERSION="24.0"
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		libncurses5 \
 		libodbc1 \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,7 +5,7 @@ FROM cimg/%%PARENT%%:2021.07
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
 # Install Erlang via Erlang Solutions' .deb
-ENV ERLANG_VERSION="24.0"
+ENV ERLANG_VERSION="24.0.4"
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		libncurses5 \
 		libodbc1 \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,7 +5,7 @@ FROM cimg/%%PARENT%%:2021.07
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
 # Install Erlang via Erlang Solutions' .deb
-ENV ERLANG_VERSION="24.0.4"
+ENV ERLANG_VERSION="24.0.5"
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		libncurses5 \
 		libodbc1 \


### PR DESCRIPTION
💁 There have been two patch releases of Erlang/OTP since version 24.0.4. Releasing the lock on this specific patch version will enable access to newer bug fixes. For example, OTP v24.0.6 has a significant amount of [fixes to the Erlang Run-Time System Application](https://github.com/erlang/otp/releases/tag/OTP-24.0.6) which I'd like to have access to while running test suites.

~Reverts CircleCI-Public/cimg-elixir#59~ Updates Erlang/OTP to the current generally available version published by Erlang Solutions: 24.0.5.