### PR TITLE
Update Erlang/OTP to v24.1.7

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,7 +5,7 @@ FROM cimg/%%PARENT%%:2021.07
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
 # Install Erlang via Erlang Solutions' .deb
-ENV ERLANG_VERSION="24.0.5"
+ENV ERLANG_VERSION="24.1.7"
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		libncurses5 \
 		libodbc1 \


### PR DESCRIPTION
💁 There have been 9 updates to the 24.x series of Erlang/OTP since OTP was last updated in this template. This change updates it to the generally available  24.1.7 version[1] published by Erlang Solutions, which also matches the OTP version in the Docker image maintained by the Erlang Foundation[2].

1: https://github.com/erlang/otp/releases/tag/OTP-24.1.7
2: https://github.com/erlef/docker-elixir/blob/0b0bff16725b9c267e1380aef2cdcc328d597c5f/1.13/Dockerfile