### PR TITLE
Update Erlang/OTP to v24.3.3

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -7,7 +7,7 @@ FROM cimg/%%PARENT%%:2022.01
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
 # Install Erlang via Erlang Solutions' .deb
-ENV ERLANG_VERSION="24.2"
+ENV ERLANG_VERSION="24.3.3"
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		libncurses5 \
 		libodbc1 \


### PR DESCRIPTION
There have been 6 updates to the 24.x series of Erlang/OTP since it was released in December 2021. This change updates it to the generally available 24.3.3 version[1] published by Erlang Solutions, which also matches the OTP version in the Docker image maintained by the Erlang Foundation[2].

1: https://github.com/erlang/otp/releases/tag/OTP-24.3.3
2: https://github.com/erlef/docker-elixir/blob/328f4c09d39b06502a90fa0c5bb30d6972593fac/1.13/Dockerfile