### PR TITLE
Respin Elixir v1.13.4 with multiple Erlang version support [release]

### DIFF
--- a/1.13/22.3/Dockerfile
+++ b/1.13/22.3/Dockerfile
@@ -1,0 +1,30 @@
+# vim:set ft=dockerfile:
+
+# Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
+
+FROM cimg/base:2022.01
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Erlang via Erlang Solutions' .deb
+ENV ERLANG_VERSION="22.3"
+RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+		libncurses5 \
+		libodbc1 \
+		libsctp1 \
+		libwxgtk3.0 && \
+	erlangDEB="https://packages.erlang-solutions.com/erlang/debian/pool/esl-erlang_${ERLANG_VERSION}-1~ubuntu~focal_amd64.deb" && \
+	curl -sSL -o erlang.deb $erlangDEB && \
+	sudo dpkg -i erlang.deb && \
+	sudo rm -rf erlang.deb /var/lib/apt/lists/*
+
+# Install Elixir via Erlang Solutions' .deb
+ENV ELIXIR_VERSION=1.13.4
+RUN ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/v${ELIXIR_VERSION}.tar.gz" && \
+	curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL && \
+	sudo mkdir -p /usr/local/src/elixir && \
+	sudo tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz && \
+	rm elixir-src.tar.gz && \
+	cd /usr/local/src/elixir && \
+	sudo make install clean && \
+	elixir --version

--- a/1.13/22.3/browsers/Dockerfile
+++ b/1.13/22.3/browsers/Dockerfile
@@ -1,0 +1,63 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/elixir:1.13.4-erlang-22.3-node
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+
+    # Install Java only if it's not already available
+    # Java is installed for Selenium
+    if ! command -v java > /dev/null; then \
+        echo "Java not found in parent image, installing..." && \
+        sudo apt-get install -y --no-install-recommends --no-upgrade openjdk-11-jre; \
+    fi && \
+
+    # Firefox deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+		libdbus-glib-1-2 \
+		libgtk-3-dev \
+		libxt6 \
+	&& \
+
+    # Google Chrome deps
+	# Some of these packages should be pulled into their own section
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+        fonts-liberation \
+        libappindicator3-1 \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatspi2.0-0 \
+        libcairo2 \
+        libcups2 \
+        libgbm1 \
+        libgdk-pixbuf2.0-0 \
+        libgtk-3-0 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libxcursor1 \
+		libxss1 \
+        xdg-utils \
+		xvfb \
+	&& \
+	sudo rm -rf /var/lib/apt/lists/*
+
+# Below is setup to allow xvfb to start when the container starts up.
+# The label in particular allows this image to override what CircleCI does
+# when booting the image.
+LABEL com.circleci.preserve-entrypoint=true
+ENV DISPLAY=":99"
+#RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint && \
+#	chmod +x /tmp/entrypoint && \
+#	sudo mv /tmp/entrypoint /docker-entrypoint.sh
+RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo tee /docker-entrypoint.sh && \
+	sudo chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/bin/sh"]

--- a/1.13/22.3/node/Dockerfile
+++ b/1.13/22.3/node/Dockerfile
@@ -1,0 +1,20 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/elixir:1.13.4-erlang-22.3
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Dockerfile will pull the latest LTS release from cimg-node.
+RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/main/ALIASES" -o nodeAliases.txt && \
+	NODE_VERSION=$(grep "lts" ./nodeAliases.txt | cut -d "=" -f 2-) && \
+	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz nodeAliases.txt && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.22.5
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/1.13/23.3/Dockerfile
+++ b/1.13/23.3/Dockerfile
@@ -1,0 +1,30 @@
+# vim:set ft=dockerfile:
+
+# Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
+
+FROM cimg/base:2022.01
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Erlang via Erlang Solutions' .deb
+ENV ERLANG_VERSION="23.3"
+RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+		libncurses5 \
+		libodbc1 \
+		libsctp1 \
+		libwxgtk3.0 && \
+	erlangDEB="https://packages.erlang-solutions.com/erlang/debian/pool/esl-erlang_${ERLANG_VERSION}-1~ubuntu~focal_amd64.deb" && \
+	curl -sSL -o erlang.deb $erlangDEB && \
+	sudo dpkg -i erlang.deb && \
+	sudo rm -rf erlang.deb /var/lib/apt/lists/*
+
+# Install Elixir via Erlang Solutions' .deb
+ENV ELIXIR_VERSION=1.13.4
+RUN ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/v${ELIXIR_VERSION}.tar.gz" && \
+	curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL && \
+	sudo mkdir -p /usr/local/src/elixir && \
+	sudo tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz && \
+	rm elixir-src.tar.gz && \
+	cd /usr/local/src/elixir && \
+	sudo make install clean && \
+	elixir --version

--- a/1.13/23.3/browsers/Dockerfile
+++ b/1.13/23.3/browsers/Dockerfile
@@ -1,0 +1,63 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/elixir:1.13.4-erlang-23.3-node
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+
+    # Install Java only if it's not already available
+    # Java is installed for Selenium
+    if ! command -v java > /dev/null; then \
+        echo "Java not found in parent image, installing..." && \
+        sudo apt-get install -y --no-install-recommends --no-upgrade openjdk-11-jre; \
+    fi && \
+
+    # Firefox deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+		libdbus-glib-1-2 \
+		libgtk-3-dev \
+		libxt6 \
+	&& \
+
+    # Google Chrome deps
+	# Some of these packages should be pulled into their own section
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+        fonts-liberation \
+        libappindicator3-1 \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatspi2.0-0 \
+        libcairo2 \
+        libcups2 \
+        libgbm1 \
+        libgdk-pixbuf2.0-0 \
+        libgtk-3-0 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libxcursor1 \
+		libxss1 \
+        xdg-utils \
+		xvfb \
+	&& \
+	sudo rm -rf /var/lib/apt/lists/*
+
+# Below is setup to allow xvfb to start when the container starts up.
+# The label in particular allows this image to override what CircleCI does
+# when booting the image.
+LABEL com.circleci.preserve-entrypoint=true
+ENV DISPLAY=":99"
+#RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint && \
+#	chmod +x /tmp/entrypoint && \
+#	sudo mv /tmp/entrypoint /docker-entrypoint.sh
+RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo tee /docker-entrypoint.sh && \
+	sudo chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/bin/sh"]

--- a/1.13/23.3/node/Dockerfile
+++ b/1.13/23.3/node/Dockerfile
@@ -1,0 +1,20 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/elixir:1.13.4-erlang-23.3
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Dockerfile will pull the latest LTS release from cimg-node.
+RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/main/ALIASES" -o nodeAliases.txt && \
+	NODE_VERSION=$(grep "lts" ./nodeAliases.txt | cut -d "=" -f 2-) && \
+	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz nodeAliases.txt && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.22.5
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/1.13/24.3/Dockerfile
+++ b/1.13/24.3/Dockerfile
@@ -1,0 +1,30 @@
+# vim:set ft=dockerfile:
+
+# Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
+
+FROM cimg/base:2022.01
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Erlang via Erlang Solutions' .deb
+ENV ERLANG_VERSION="24.3"
+RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+		libncurses5 \
+		libodbc1 \
+		libsctp1 \
+		libwxgtk3.0 && \
+	erlangDEB="https://packages.erlang-solutions.com/erlang/debian/pool/esl-erlang_${ERLANG_VERSION}-1~ubuntu~focal_amd64.deb" && \
+	curl -sSL -o erlang.deb $erlangDEB && \
+	sudo dpkg -i erlang.deb && \
+	sudo rm -rf erlang.deb /var/lib/apt/lists/*
+
+# Install Elixir via Erlang Solutions' .deb
+ENV ELIXIR_VERSION=1.13.4
+RUN ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/v${ELIXIR_VERSION}.tar.gz" && \
+	curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL && \
+	sudo mkdir -p /usr/local/src/elixir && \
+	sudo tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz && \
+	rm elixir-src.tar.gz && \
+	cd /usr/local/src/elixir && \
+	sudo make install clean && \
+	elixir --version

--- a/1.13/24.3/browsers/Dockerfile
+++ b/1.13/24.3/browsers/Dockerfile
@@ -1,0 +1,63 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/elixir:1.13.4-erlang-24.3-node
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+
+    # Install Java only if it's not already available
+    # Java is installed for Selenium
+    if ! command -v java > /dev/null; then \
+        echo "Java not found in parent image, installing..." && \
+        sudo apt-get install -y --no-install-recommends --no-upgrade openjdk-11-jre; \
+    fi && \
+
+    # Firefox deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+		libdbus-glib-1-2 \
+		libgtk-3-dev \
+		libxt6 \
+	&& \
+
+    # Google Chrome deps
+	# Some of these packages should be pulled into their own section
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+        fonts-liberation \
+        libappindicator3-1 \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatspi2.0-0 \
+        libcairo2 \
+        libcups2 \
+        libgbm1 \
+        libgdk-pixbuf2.0-0 \
+        libgtk-3-0 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libxcursor1 \
+		libxss1 \
+        xdg-utils \
+		xvfb \
+	&& \
+	sudo rm -rf /var/lib/apt/lists/*
+
+# Below is setup to allow xvfb to start when the container starts up.
+# The label in particular allows this image to override what CircleCI does
+# when booting the image.
+LABEL com.circleci.preserve-entrypoint=true
+ENV DISPLAY=":99"
+#RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint && \
+#	chmod +x /tmp/entrypoint && \
+#	sudo mv /tmp/entrypoint /docker-entrypoint.sh
+RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo tee /docker-entrypoint.sh && \
+	sudo chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/bin/sh"]

--- a/1.13/24.3/node/Dockerfile
+++ b/1.13/24.3/node/Dockerfile
@@ -1,0 +1,20 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/elixir:1.13.4-erlang-24.3
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Dockerfile will pull the latest LTS release from cimg-node.
+RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/main/ALIASES" -o nodeAliases.txt && \
+	NODE_VERSION=$(grep "lts" ./nodeAliases.txt | cut -d "=" -f 2-) && \
+	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz nodeAliases.txt && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.22.5
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker build --file 1.13/Dockerfile -t cimg/elixir:1.13.4  -t cimg/elixir:1.13 .
-docker build --file 1.13/node/Dockerfile -t cimg/elixir:1.13.4-node  -t cimg/elixir:1.13-node .
-docker build --file 1.13/browsers/Dockerfile -t cimg/elixir:1.13.4-browsers  -t cimg/elixir:1.13-browsers .
+docker build --file 1.13/22.3/Dockerfile -t cimg/elixir:1.13.4-erlang-22.3 -t cimg/elixir:1.13-erlang-22.3 .
+docker build --file 1.13/22.3/node/Dockerfile -t cimg/elixir:1.13.4-erlang-22.3-node -t cimg/elixir:1.13-erlang-22.3-node .
+docker build --file 1.13/22.3/browsers/Dockerfile -t cimg/elixir:1.13.4-erlang-22.3-browsers -t cimg/elixir:1.13-erlang-22.3-browsers .
+docker build --file 1.13/23.3/Dockerfile -t cimg/elixir:1.13.4-erlang-23.3 -t cimg/elixir:1.13-erlang-23.3 .
+docker build --file 1.13/23.3/node/Dockerfile -t cimg/elixir:1.13.4-erlang-23.3-node -t cimg/elixir:1.13-erlang-23.3-node .
+docker build --file 1.13/23.3/browsers/Dockerfile -t cimg/elixir:1.13.4-erlang-23.3-browsers -t cimg/elixir:1.13-erlang-23.3-browsers .
+docker build --file 1.13/24.3/Dockerfile -t cimg/elixir:1.13.4-erlang-24.3 -t cimg/elixir:1.13-erlang-24.3 .
+docker build --file 1.13/24.3/node/Dockerfile -t cimg/elixir:1.13.4-erlang-24.3-node -t cimg/elixir:1.13-erlang-24.3-node .
+docker build --file 1.13/24.3/browsers/Dockerfile -t cimg/elixir:1.13.4-erlang-24.3-browsers -t cimg/elixir:1.13-erlang-24.3-browsers .

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,9 +1,26 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
-
-docker push cimg/elixir:1.13.4
-docker push cimg/elixir:1.13
-docker push cimg/elixir:1.13.4-node
-docker push cimg/elixir:1.13-node
-docker push cimg/elixir:1.13.4-browsers
-docker push cimg/elixir:1.13-browsers
+docker push cimg/elixir:1.13-erlang-22.3
+docker push cimg/elixir:1.13.4-erlang-22.3
+docker push cimg/elixir:1.13-erlang-22.3-node
+docker push cimg/elixir:1.13.4-erlang-22.3-node
+docker push cimg/elixir:1.13-erlang-22.3-browsers
+docker push cimg/elixir:1.13.4-erlang-22.3-browsers
+docker push cimg/elixir:1.13-erlang-23.3
+docker push cimg/elixir:1.13.4-erlang-23.3
+docker push cimg/elixir:1.13-erlang-23.3-node
+docker push cimg/elixir:1.13.4-erlang-23.3-node
+docker push cimg/elixir:1.13-erlang-23.3-browsers
+docker push cimg/elixir:1.13.4-erlang-23.3-browsers
+docker push cimg/elixir:1.13-erlang-24.3
+docker push cimg/elixir:1.13.4-erlang-24.3
+docker tag cimg/elixir:1.13.4-erlang-24.3 cimg/elixir:1.13.4
+docker tag cimg/elixir:1.13-erlang-24.3 cimg/elixir:1.13
+docker push cimg/elixir:1.13-erlang-24.3-node
+docker push cimg/elixir:1.13.4-erlang-24.3-node
+docker tag cimg/elixir:1.13.4-erlang-24.3-node cimg/elixir:1.13.4-node
+docker tag cimg/elixir:1.13-erlang-24.3-node cimg/elixir:1.13-node
+docker push cimg/elixir:1.13-erlang-24.3-browsers
+docker push cimg/elixir:1.13.4-erlang-24.3-browsers
+docker tag cimg/elixir:1.13.4-erlang-24.3-browsers cimg/elixir:1.13.4-browsers
+docker tag cimg/elixir:1.13-erlang-24.3-browsers cimg/elixir:1.13-browsers


### PR DESCRIPTION
respins the latest version of elixir: 1.13.4 with parentTag support

Would also close #74 