### PR TITLE
fix: 1.14-22.3 did not build due to invalid erlang url

### DIFF
--- a/manifest
+++ b/manifest
@@ -4,6 +4,6 @@ repository=elixir
 parent=base
 variants=(node browsers)
 namespace=cimg
-parentTags=(22.3 23.3 24.3 25.0.4)
+parentTags=(22.3.4 23.3.1 24.3.3 25.0.4)
 defaultParentTag=25.0.4
 parentSlug=erlang


### PR DESCRIPTION
the erlang version specified in the manifest, 22.3 was not available as a valid download from erlang solutions. This moves versions to semver and the latest versions that have valid links for ubuntu focal. 

new releases will likely need to be cut, at least for 1.14-22.3 as that seems to be the only one affected at the moment