### PR TITLE
update: remove erlang 22

### DIFF
--- a/manifest
+++ b/manifest
@@ -4,6 +4,6 @@ repository=elixir
 parent=base
 variants=(node browsers)
 namespace=cimg
-parentTags=(22.3.4 23.3.1 24.3.3 25.0.4)
+parentTags=(23.3.1 24.3.3 25.0.4)
 defaultParentTag=25.0.4
 parentSlug=erlang


### PR DESCRIPTION
the only releases that the elixir team are managing do not include any versions of elixir that would be compatible with erlang 22, hence why 1.14 was not building the erlang 22 version 

https://hexdocs.pm/elixir/main/compatibility-and-deprecations.html

technically also closes #92 