### PR TITLE
Publish v1.14.3. [release]

### DIFF
--- a/1.14/23.3.1/Dockerfile
+++ b/1.14/23.3.1/Dockerfile
@@ -2,10 +2,13 @@
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
 
-# By policy, the base image tag should be a quarterly tag unless there's a 
-# specific reason to use a different one. This means January, April, July, or 
+# By policy, the base image tag should be a quarterly tag unless there's a
+# specific reason to use a different one. This means January, April, July, or
 # October.
-FROM cimg/base:2022.10-20.04
+
+# Erlang version 23.3 does not support OpenSSL3, which means only for this specific version do we need to use 20.04. Please adjust accordingly
+
+FROM cimg/base:2023.01-20.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -22,7 +25,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	sudo rm -rf erlang.deb /var/lib/apt/lists/*
 
 # Install Elixir via Erlang Solutions' .deb
-ENV ELIXIR_VERSION=1.14.2
+ENV ELIXIR_VERSION=1.14.3
 RUN ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/v${ELIXIR_VERSION}.tar.gz" && \
 	curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL && \
 	sudo mkdir -p /usr/local/src/elixir && \

--- a/1.14/23.3.1/browsers/Dockerfile
+++ b/1.14/23.3.1/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/elixir:1.14.2-erlang-23.3.1-node
+FROM cimg/elixir:1.14.3-erlang-23.3.1-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -11,6 +11,9 @@ RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://seleniu
     rm selenium-server-standalone-${SELENIUM_VER}.jar
 
 RUN sudo apt-get update && \
+	sudo apt-get install --yes --no-install-recommends \
+		xvfb \
+	&& \
 
     # Install Java only if it's not already available
     # Java is installed for Selenium
@@ -32,25 +35,22 @@ RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo te
 	sudo chmod +x /docker-entrypoint.sh
 
 # Install a single version of Firefox. This isn't intended to be a regularly
-# updated thing. Instead, if this version of Firefox isn't want the end user
+# updated thing. Instead, if this version of Firefox isn't what the end user
 # wants they should install a different version via the Browser Tools Orb.
 #
 # Canonical made a major technology change in how Firefox is installed from
 # Ubuntu 21.10 and up. The general CI space doesn't seem to be ready for a snap
-# based Firefox right now so we are installing the original deb based version
-# from Ubuntu Focal, even if the current Ubuntu version is newer.
-RUN echo 'deb http://us.archive.ubuntu.com/ubuntu/ focal-updates main' | sudo tee /etc/apt/sources.list.d/firefox.list && \
-	echo 'Package: firefox' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
-	echo 'Pin: release n=focal' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
-	echo 'Pin-Priority: 500' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
-
-	sudo apt-get update && \
+# based Firefox right now so we are installing it from the Mozilla PPA.
+RUN echo 'Package: *' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	echo 'Pin: release o=LP-PPA-mozillateam' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	echo 'Pin-Priority: 1001' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	sudo add-apt-repository --yes ppa:mozillateam/ppa && \
 	sudo apt-get install --no-install-recommends --yes firefox && \
 	sudo rm -rf /var/lib/apt/lists/* && \
 	firefox --version
 
 # Install a single version of Google Chrome Stable. This isn't intended to be a
-# regularly updated thing. Instead, if this version of Chrome isn't want the
+# regularly updated thing. Instead, if this version of Chrome isn't what the
 # end user wants they should install a different version via the Browser Tools
 # Orb.
 RUN wget -q -O - "https://dl.google.com/linux/linux_signing_key.pub" | sudo apt-key add - && \

--- a/1.14/23.3.1/node/Dockerfile
+++ b/1.14/23.3.1/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/elixir:1.14.2-erlang-23.3.1
+FROM cimg/elixir:1.14.3-erlang-23.3.1
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -12,7 +12,7 @@ RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/main/
 	rm node.tar.xz nodeAliases.txt && \
 	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.22.18
+ENV YARN_VERSION 1.22.19
 RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \

--- a/1.14/24.3.3/Dockerfile
+++ b/1.14/24.3.3/Dockerfile
@@ -2,10 +2,13 @@
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
 
-# By policy, the base image tag should be a quarterly tag unless there's a 
-# specific reason to use a different one. This means January, April, July, or 
+# By policy, the base image tag should be a quarterly tag unless there's a
+# specific reason to use a different one. This means January, April, July, or
 # October.
-FROM cimg/base:2022.10-20.04
+
+# Erlang version 23.3 does not support OpenSSL3, which means only for this specific version do we need to use 20.04. Please adjust accordingly
+
+FROM cimg/base:2023.01-20.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -22,7 +25,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	sudo rm -rf erlang.deb /var/lib/apt/lists/*
 
 # Install Elixir via Erlang Solutions' .deb
-ENV ELIXIR_VERSION=1.14.2
+ENV ELIXIR_VERSION=1.14.3
 RUN ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/v${ELIXIR_VERSION}.tar.gz" && \
 	curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL && \
 	sudo mkdir -p /usr/local/src/elixir && \

--- a/1.14/24.3.3/browsers/Dockerfile
+++ b/1.14/24.3.3/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/elixir:1.14.2-erlang-24.3.3-node
+FROM cimg/elixir:1.14.3-erlang-24.3.3-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -11,6 +11,9 @@ RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://seleniu
     rm selenium-server-standalone-${SELENIUM_VER}.jar
 
 RUN sudo apt-get update && \
+	sudo apt-get install --yes --no-install-recommends \
+		xvfb \
+	&& \
 
     # Install Java only if it's not already available
     # Java is installed for Selenium
@@ -32,25 +35,22 @@ RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo te
 	sudo chmod +x /docker-entrypoint.sh
 
 # Install a single version of Firefox. This isn't intended to be a regularly
-# updated thing. Instead, if this version of Firefox isn't want the end user
+# updated thing. Instead, if this version of Firefox isn't what the end user
 # wants they should install a different version via the Browser Tools Orb.
 #
 # Canonical made a major technology change in how Firefox is installed from
 # Ubuntu 21.10 and up. The general CI space doesn't seem to be ready for a snap
-# based Firefox right now so we are installing the original deb based version
-# from Ubuntu Focal, even if the current Ubuntu version is newer.
-RUN echo 'deb http://us.archive.ubuntu.com/ubuntu/ focal-updates main' | sudo tee /etc/apt/sources.list.d/firefox.list && \
-	echo 'Package: firefox' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
-	echo 'Pin: release n=focal' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
-	echo 'Pin-Priority: 500' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
-
-	sudo apt-get update && \
+# based Firefox right now so we are installing it from the Mozilla PPA.
+RUN echo 'Package: *' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	echo 'Pin: release o=LP-PPA-mozillateam' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	echo 'Pin-Priority: 1001' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	sudo add-apt-repository --yes ppa:mozillateam/ppa && \
 	sudo apt-get install --no-install-recommends --yes firefox && \
 	sudo rm -rf /var/lib/apt/lists/* && \
 	firefox --version
 
 # Install a single version of Google Chrome Stable. This isn't intended to be a
-# regularly updated thing. Instead, if this version of Chrome isn't want the
+# regularly updated thing. Instead, if this version of Chrome isn't what the
 # end user wants they should install a different version via the Browser Tools
 # Orb.
 RUN wget -q -O - "https://dl.google.com/linux/linux_signing_key.pub" | sudo apt-key add - && \

--- a/1.14/24.3.3/node/Dockerfile
+++ b/1.14/24.3.3/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/elixir:1.14.2-erlang-24.3.3
+FROM cimg/elixir:1.14.3-erlang-24.3.3
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -12,7 +12,7 @@ RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/main/
 	rm node.tar.xz nodeAliases.txt && \
 	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.22.18
+ENV YARN_VERSION 1.22.19
 RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \

--- a/1.14/25.0.4/Dockerfile
+++ b/1.14/25.0.4/Dockerfile
@@ -2,10 +2,13 @@
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
 
-# By policy, the base image tag should be a quarterly tag unless there's a 
-# specific reason to use a different one. This means January, April, July, or 
+# By policy, the base image tag should be a quarterly tag unless there's a
+# specific reason to use a different one. This means January, April, July, or
 # October.
-FROM cimg/base:2022.10-20.04
+
+# Erlang version 23.3 does not support OpenSSL3, which means only for this specific version do we need to use 20.04. Please adjust accordingly
+
+FROM cimg/base:2023.01-20.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -22,7 +25,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	sudo rm -rf erlang.deb /var/lib/apt/lists/*
 
 # Install Elixir via Erlang Solutions' .deb
-ENV ELIXIR_VERSION=1.14.2
+ENV ELIXIR_VERSION=1.14.3
 RUN ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/v${ELIXIR_VERSION}.tar.gz" && \
 	curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL && \
 	sudo mkdir -p /usr/local/src/elixir && \

--- a/1.14/25.0.4/browsers/Dockerfile
+++ b/1.14/25.0.4/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/elixir:1.14.2-erlang-25.0.4-node
+FROM cimg/elixir:1.14.3-erlang-25.0.4-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -11,6 +11,9 @@ RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://seleniu
     rm selenium-server-standalone-${SELENIUM_VER}.jar
 
 RUN sudo apt-get update && \
+	sudo apt-get install --yes --no-install-recommends \
+		xvfb \
+	&& \
 
     # Install Java only if it's not already available
     # Java is installed for Selenium
@@ -32,25 +35,22 @@ RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo te
 	sudo chmod +x /docker-entrypoint.sh
 
 # Install a single version of Firefox. This isn't intended to be a regularly
-# updated thing. Instead, if this version of Firefox isn't want the end user
+# updated thing. Instead, if this version of Firefox isn't what the end user
 # wants they should install a different version via the Browser Tools Orb.
 #
 # Canonical made a major technology change in how Firefox is installed from
 # Ubuntu 21.10 and up. The general CI space doesn't seem to be ready for a snap
-# based Firefox right now so we are installing the original deb based version
-# from Ubuntu Focal, even if the current Ubuntu version is newer.
-RUN echo 'deb http://us.archive.ubuntu.com/ubuntu/ focal-updates main' | sudo tee /etc/apt/sources.list.d/firefox.list && \
-	echo 'Package: firefox' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
-	echo 'Pin: release n=focal' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
-	echo 'Pin-Priority: 500' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
-
-	sudo apt-get update && \
+# based Firefox right now so we are installing it from the Mozilla PPA.
+RUN echo 'Package: *' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	echo 'Pin: release o=LP-PPA-mozillateam' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	echo 'Pin-Priority: 1001' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	sudo add-apt-repository --yes ppa:mozillateam/ppa && \
 	sudo apt-get install --no-install-recommends --yes firefox && \
 	sudo rm -rf /var/lib/apt/lists/* && \
 	firefox --version
 
 # Install a single version of Google Chrome Stable. This isn't intended to be a
-# regularly updated thing. Instead, if this version of Chrome isn't want the
+# regularly updated thing. Instead, if this version of Chrome isn't what the
 # end user wants they should install a different version via the Browser Tools
 # Orb.
 RUN wget -q -O - "https://dl.google.com/linux/linux_signing_key.pub" | sudo apt-key add - && \

--- a/1.14/25.0.4/node/Dockerfile
+++ b/1.14/25.0.4/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/elixir:1.14.2-erlang-25.0.4
+FROM cimg/elixir:1.14.3-erlang-25.0.4
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -12,7 +12,7 @@ RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/main/
 	rm node.tar.xz nodeAliases.txt && \
 	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.22.18
+ENV YARN_VERSION 1.22.19
 RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -2,10 +2,13 @@
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
 
-# By policy, the base image tag should be a quarterly tag unless there's a 
-# specific reason to use a different one. This means January, April, July, or 
+# By policy, the base image tag should be a quarterly tag unless there's a
+# specific reason to use a different one. This means January, April, July, or
 # October.
-FROM cimg/%%PARENT%%:2022.10-20.04
+
+# Erlang version 23.3 does not support OpenSSL3, which means only for this specific version do we need to use 20.04. Please adjust accordingly
+
+FROM cimg/%%PARENT%%:2023.01-20.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/GEN-CHECK
+++ b/GEN-CHECK
@@ -1,1 +1,1 @@
-GEN_CHECK=(1.14.2)
+GEN_CHECK=(1.14.3)

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker build --file 1.14/23.3.1/Dockerfile -t cimg/elixir:1.14.2-erlang-23.3.1 -t cimg/elixir:1.14-erlang-23.3.1 .
-docker build --file 1.14/23.3.1/node/Dockerfile -t cimg/elixir:1.14.2-erlang-23.3.1-node -t cimg/elixir:1.14-erlang-23.3.1-node .
-docker build --file 1.14/23.3.1/browsers/Dockerfile -t cimg/elixir:1.14.2-erlang-23.3.1-browsers -t cimg/elixir:1.14-erlang-23.3.1-browsers .
-docker build --file 1.14/24.3.3/Dockerfile -t cimg/elixir:1.14.2-erlang-24.3.3 -t cimg/elixir:1.14-erlang-24.3.3 .
-docker build --file 1.14/24.3.3/node/Dockerfile -t cimg/elixir:1.14.2-erlang-24.3.3-node -t cimg/elixir:1.14-erlang-24.3.3-node .
-docker build --file 1.14/24.3.3/browsers/Dockerfile -t cimg/elixir:1.14.2-erlang-24.3.3-browsers -t cimg/elixir:1.14-erlang-24.3.3-browsers .
-docker build --file 1.14/25.0.4/Dockerfile -t cimg/elixir:1.14.2-erlang-25.0.4 -t cimg/elixir:1.14-erlang-25.0.4 .
-docker build --file 1.14/25.0.4/node/Dockerfile -t cimg/elixir:1.14.2-erlang-25.0.4-node -t cimg/elixir:1.14-erlang-25.0.4-node .
-docker build --file 1.14/25.0.4/browsers/Dockerfile -t cimg/elixir:1.14.2-erlang-25.0.4-browsers -t cimg/elixir:1.14-erlang-25.0.4-browsers .
+docker build --file 1.14/23.3.1/Dockerfile -t cimg/elixir:1.14.3-erlang-23.3.1 -t cimg/elixir:1.14-erlang-23.3.1 --platform linux/amd64 .
+docker build --file 1.14/23.3.1/node/Dockerfile -t cimg/elixir:1.14.3-erlang-23.3.1-node -t cimg/elixir:1.14-erlang-23.3.1-node --platform linux/amd64 .
+docker build --file 1.14/23.3.1/browsers/Dockerfile -t cimg/elixir:1.14.3-erlang-23.3.1-browsers -t cimg/elixir:1.14-erlang-23.3.1-browsers --platform linux/amd64 .
+docker build --file 1.14/24.3.3/Dockerfile -t cimg/elixir:1.14.3-erlang-24.3.3 -t cimg/elixir:1.14-erlang-24.3.3 --platform linux/amd64 .
+docker build --file 1.14/24.3.3/node/Dockerfile -t cimg/elixir:1.14.3-erlang-24.3.3-node -t cimg/elixir:1.14-erlang-24.3.3-node --platform linux/amd64 .
+docker build --file 1.14/24.3.3/browsers/Dockerfile -t cimg/elixir:1.14.3-erlang-24.3.3-browsers -t cimg/elixir:1.14-erlang-24.3.3-browsers --platform linux/amd64 .
+docker build --file 1.14/25.0.4/Dockerfile -t cimg/elixir:1.14.3-erlang-25.0.4 -t cimg/elixir:1.14-erlang-25.0.4 --platform linux/amd64 .
+docker build --file 1.14/25.0.4/node/Dockerfile -t cimg/elixir:1.14.3-erlang-25.0.4-node -t cimg/elixir:1.14-erlang-25.0.4-node --platform linux/amd64 .
+docker build --file 1.14/25.0.4/browsers/Dockerfile -t cimg/elixir:1.14.3-erlang-25.0.4-browsers -t cimg/elixir:1.14-erlang-25.0.4-browsers --platform linux/amd64 .

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,32 +1,32 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 docker push cimg/elixir:1.14-erlang-23.3.1
-docker push cimg/elixir:1.14.2-erlang-23.3.1
+docker push cimg/elixir:1.14.3-erlang-23.3.1
 docker push cimg/elixir:1.14-erlang-23.3.1-node
-docker push cimg/elixir:1.14.2-erlang-23.3.1-node
+docker push cimg/elixir:1.14.3-erlang-23.3.1-node
 docker push cimg/elixir:1.14-erlang-23.3.1-browsers
-docker push cimg/elixir:1.14.2-erlang-23.3.1-browsers
+docker push cimg/elixir:1.14.3-erlang-23.3.1-browsers
 docker push cimg/elixir:1.14-erlang-24.3.3
-docker push cimg/elixir:1.14.2-erlang-24.3.3
+docker push cimg/elixir:1.14.3-erlang-24.3.3
 docker push cimg/elixir:1.14-erlang-24.3.3-node
-docker push cimg/elixir:1.14.2-erlang-24.3.3-node
+docker push cimg/elixir:1.14.3-erlang-24.3.3-node
 docker push cimg/elixir:1.14-erlang-24.3.3-browsers
-docker push cimg/elixir:1.14.2-erlang-24.3.3-browsers
+docker push cimg/elixir:1.14.3-erlang-24.3.3-browsers
 docker push cimg/elixir:1.14-erlang-25.0.4
-docker push cimg/elixir:1.14.2-erlang-25.0.4
-docker tag cimg/elixir:1.14.2-erlang-25.0.4 cimg/elixir:1.14.2
+docker push cimg/elixir:1.14.3-erlang-25.0.4
+docker tag cimg/elixir:1.14.3-erlang-25.0.4 cimg/elixir:1.14.3
 docker tag cimg/elixir:1.14-erlang-25.0.4 cimg/elixir:1.14
 docker push cimg/elixir:1.14
-docker push cimg/elixir:1.14.2
+docker push cimg/elixir:1.14.3
 docker push cimg/elixir:1.14-erlang-25.0.4-node
-docker push cimg/elixir:1.14.2-erlang-25.0.4-node
-docker tag cimg/elixir:1.14.2-erlang-25.0.4-node cimg/elixir:1.14.2-node
+docker push cimg/elixir:1.14.3-erlang-25.0.4-node
+docker tag cimg/elixir:1.14.3-erlang-25.0.4-node cimg/elixir:1.14.3-node
 docker tag cimg/elixir:1.14-erlang-25.0.4-node cimg/elixir:1.14-node
 docker push cimg/elixir:1.14-node
-docker push cimg/elixir:1.14.2-node
+docker push cimg/elixir:1.14.3-node
 docker push cimg/elixir:1.14-erlang-25.0.4-browsers
-docker push cimg/elixir:1.14.2-erlang-25.0.4-browsers
-docker tag cimg/elixir:1.14.2-erlang-25.0.4-browsers cimg/elixir:1.14.2-browsers
+docker push cimg/elixir:1.14.3-erlang-25.0.4-browsers
+docker tag cimg/elixir:1.14.3-erlang-25.0.4-browsers cimg/elixir:1.14.3-browsers
 docker tag cimg/elixir:1.14-erlang-25.0.4-browsers cimg/elixir:1.14-browsers
 docker push cimg/elixir:1.14-browsers
-docker push cimg/elixir:1.14.2-browsers
+docker push cimg/elixir:1.14.3-browsers


### PR DESCRIPTION
Closes #104

Erlang 23.3 (and really, any version before 25, is not planned for openssl3 support), therefore, this image continues to use Ubuntu 20.04 for now