### PR TITLE
Publish v1.15.4. [release]

### DIFF
--- a/1.15/24.3.3/Dockerfile
+++ b/1.15/24.3.3/Dockerfile
@@ -8,7 +8,7 @@
 
 # Erlang version 23.3 does not support OpenSSL3, which means only for this specific version do we need to use 20.04. Please adjust accordingly
 
-FROM cimg/base:2023.04-20.04
+FROM cimg/base:2023.07-20.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -25,7 +25,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	sudo rm -rf erlang.deb /var/lib/apt/lists/*
 
 # Install Elixir via Erlang Solutions' .deb
-ENV ELIXIR_VERSION=1.15
+ENV ELIXIR_VERSION=1.15.4
 RUN ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/v${ELIXIR_VERSION}.tar.gz" && \
 	curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL && \
 	sudo mkdir -p /usr/local/src/elixir && \

--- a/1.15/24.3.3/browsers/Dockerfile
+++ b/1.15/24.3.3/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/elixir:1.15-erlang-24.3.3-node
+FROM cimg/elixir:1.15.4-erlang-24.3.3-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/1.15/24.3.3/node/Dockerfile
+++ b/1.15/24.3.3/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/elixir:1.15-erlang-24.3.3
+FROM cimg/elixir:1.15.4-erlang-24.3.3
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/1.15/25.3/Dockerfile
+++ b/1.15/25.3/Dockerfile
@@ -8,7 +8,7 @@
 
 # Erlang version 23.3 does not support OpenSSL3, which means only for this specific version do we need to use 20.04. Please adjust accordingly
 
-FROM cimg/base:2023.04-20.04
+FROM cimg/base:2023.07-20.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -25,7 +25,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	sudo rm -rf erlang.deb /var/lib/apt/lists/*
 
 # Install Elixir via Erlang Solutions' .deb
-ENV ELIXIR_VERSION=1.15
+ENV ELIXIR_VERSION=1.15.4
 RUN ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/v${ELIXIR_VERSION}.tar.gz" && \
 	curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL && \
 	sudo mkdir -p /usr/local/src/elixir && \

--- a/1.15/25.3/browsers/Dockerfile
+++ b/1.15/25.3/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/elixir:1.15-erlang-25.3-node
+FROM cimg/elixir:1.15.4-erlang-25.3-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/1.15/25.3/node/Dockerfile
+++ b/1.15/25.3/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/elixir:1.15-erlang-25.3
+FROM cimg/elixir:1.15.4-erlang-25.3
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -8,7 +8,7 @@
 
 # Erlang version 23.3 does not support OpenSSL3, which means only for this specific version do we need to use 20.04. Please adjust accordingly
 
-FROM cimg/%%PARENT%%:2023.04-20.04
+FROM cimg/%%PARENT%%:2023.07-20.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/GEN-CHECK
+++ b/GEN-CHECK
@@ -1,1 +1,1 @@
-GEN_CHECK=(1.15)
+GEN_CHECK=(1.15.4)

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker build --file 1.15/24.3.3/Dockerfile -t cimg/elixir:1.15-erlang-24.3.3 -t cimg/elixir:1.15-erlang-24.3.3 --platform linux/amd64 .
-docker build --file 1.15/24.3.3/node/Dockerfile -t cimg/elixir:1.15-erlang-24.3.3-node -t cimg/elixir:1.15-erlang-24.3.3-node --platform linux/amd64 .
-docker build --file 1.15/24.3.3/browsers/Dockerfile -t cimg/elixir:1.15-erlang-24.3.3-browsers -t cimg/elixir:1.15-erlang-24.3.3-browsers --platform linux/amd64 .
-docker build --file 1.15/25.3/Dockerfile -t cimg/elixir:1.15-erlang-25.3 -t cimg/elixir:1.15-erlang-25.3 --platform linux/amd64 .
-docker build --file 1.15/25.3/node/Dockerfile -t cimg/elixir:1.15-erlang-25.3-node -t cimg/elixir:1.15-erlang-25.3-node --platform linux/amd64 .
-docker build --file 1.15/25.3/browsers/Dockerfile -t cimg/elixir:1.15-erlang-25.3-browsers -t cimg/elixir:1.15-erlang-25.3-browsers --platform linux/amd64 .
+docker build --file 1.15/24.3.3/Dockerfile -t cimg/elixir:1.15.4-erlang-24.3.3 -t cimg/elixir:1.15-erlang-24.3.3 --platform linux/amd64 .
+docker build --file 1.15/24.3.3/node/Dockerfile -t cimg/elixir:1.15.4-erlang-24.3.3-node -t cimg/elixir:1.15-erlang-24.3.3-node --platform linux/amd64 .
+docker build --file 1.15/24.3.3/browsers/Dockerfile -t cimg/elixir:1.15.4-erlang-24.3.3-browsers -t cimg/elixir:1.15-erlang-24.3.3-browsers --platform linux/amd64 .
+docker build --file 1.15/25.3/Dockerfile -t cimg/elixir:1.15.4-erlang-25.3 -t cimg/elixir:1.15-erlang-25.3 --platform linux/amd64 .
+docker build --file 1.15/25.3/node/Dockerfile -t cimg/elixir:1.15.4-erlang-25.3-node -t cimg/elixir:1.15-erlang-25.3-node --platform linux/amd64 .
+docker build --file 1.15/25.3/browsers/Dockerfile -t cimg/elixir:1.15.4-erlang-25.3-browsers -t cimg/elixir:1.15-erlang-25.3-browsers --platform linux/amd64 .

--- a/manifest
+++ b/manifest
@@ -4,6 +4,6 @@ repository=elixir
 parent=base
 variants=(node browsers)
 namespace=cimg
-parentTags=(23.3.4.5 24.3.3 25.3)
+parentTags=(24.3.3 25.3)
 defaultParentTag=25.3
 parentSlug=erlang

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,14 +1,26 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 docker push cimg/elixir:1.15-erlang-24.3.3
+docker push cimg/elixir:1.15.4-erlang-24.3.3
 docker push cimg/elixir:1.15-erlang-24.3.3-node
+docker push cimg/elixir:1.15.4-erlang-24.3.3-node
 docker push cimg/elixir:1.15-erlang-24.3.3-browsers
+docker push cimg/elixir:1.15.4-erlang-24.3.3-browsers
 docker push cimg/elixir:1.15-erlang-25.3
+docker push cimg/elixir:1.15.4-erlang-25.3
+docker tag cimg/elixir:1.15.4-erlang-25.3 cimg/elixir:1.15.4
 docker tag cimg/elixir:1.15-erlang-25.3 cimg/elixir:1.15
 docker push cimg/elixir:1.15
+docker push cimg/elixir:1.15.4
 docker push cimg/elixir:1.15-erlang-25.3-node
+docker push cimg/elixir:1.15.4-erlang-25.3-node
+docker tag cimg/elixir:1.15.4-erlang-25.3-node cimg/elixir:1.15.4-node
 docker tag cimg/elixir:1.15-erlang-25.3-node cimg/elixir:1.15-node
 docker push cimg/elixir:1.15-node
+docker push cimg/elixir:1.15.4-node
 docker push cimg/elixir:1.15-erlang-25.3-browsers
+docker push cimg/elixir:1.15.4-erlang-25.3-browsers
+docker tag cimg/elixir:1.15.4-erlang-25.3-browsers cimg/elixir:1.15.4-browsers
 docker tag cimg/elixir:1.15-erlang-25.3-browsers cimg/elixir:1.15-browsers
 docker push cimg/elixir:1.15-browsers
+docker push cimg/elixir:1.15.4-browsers


### PR DESCRIPTION
Publish v1.15.4. [release]

- aim to support three latest versions of erlang otp, however, erlang 23 is no longer compatible, 1.13-1.14 are EOL, with only security fixes available. Therefore, removing erlang 23 and adding 26 once erlang-solutions is able to provide.

since our users are looking to have the latest erlang otp versions more often than not, we should look into compiling our own