### PR TITLE
Update elixirFeed and add information about it

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ docker build -t test/elixir:1.10.2-erlang-24.3 .
 docker run -it test/elixir:1.10.2-erlang-24.3 bash
 ```
 
+## Elixir Feed
+
+Each execution of this script will update the required Dockerfile to the next version, and will generate a build-images.sh and push-images.sh script to build and push these Dockerfiles.
+These scripts will build and push a tag for each version from the one in the Dockerfile, to the latest, so in case the current one is no the latest, wrong images will be created for versions that are not the current, this can be solved running the feed again, which will update the Dockerfile to the next version, and will delete the previous tag from the build and push scripts. Doing this as many times as new versions are, will guarantee all tags have the proper version installed. If you stop running the script previous to get to the latest version, the newer versions will have installed the version where you stopped.
 
 ### Building the Dockerfiles
 

--- a/elixirFeed.sh
+++ b/elixirFeed.sh
@@ -38,12 +38,16 @@ getElixirVersion() {
   for version in $VERSIONS; do
     if [[ $version =~ ^v[0-9]+(\.[0-9]+)*$ ]]; then
       generateVersions "$(cut -d 'v' -f2 <<< "${version}")"
-      echo $newVersions hi
-      generateSearchTerms "ELIXIR_VERSION=" "$majorMinor/${parentTags[2]}/Dockerfile"
+      echo $newVersion hi
+      #This looks for the ELIXIR_VERSION version on the current Dockerfile and export it as SEARCH_TERM
+      generateSearchTerms "ELIXIR_VERSION=" "$majorMinor/${parentTags[-1]}/Dockerfile"
+      echo "Search term is: $SEARCH_TERM"
+      # This compares the version on the Dockerfile with the directory version
       directoryCheck "$majorMinor" "$SEARCH_TERM"
 
+      # This condition only happens when the version in the docker file is less than the version of the loop
       if [[ $(eval echo $?) == 0 ]]; then
-
+        echo "Condition met with $version"
         generateVersionString "$newVersion"
       fi
     fi


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Fix the elixirFeed so it works with any amount of parentTags in the manifest.

# Reasons
When the manifest has less than 3 parentTags the elixirFeed script gets stuck letting the version in the Dockerfile unchanged.

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
